### PR TITLE
Lz profile

### DIFF
--- a/doc/examples/example16_set_profile.c
+++ b/doc/examples/example16_set_profile.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2009-2016, Christian Ferrari <tiian@users.sourceforge.net>
+ * Parts Copyright (c) 2021, Lawrence Wilkinson <lawrence.wilkinson@lzlabs.com>
+ * All rights reserved.
+ *
+ * This file is part of LIXA.
+ *
+ * LIXA is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation.
+ *
+ * LIXA is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LIXA.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <tx.h>
+
+
+
+/* this basic example shows simple usage of the LIXA software */
+/* and the tx_set_profile() function */
+
+
+
+int main(int argc, char *argv[])
+{
+    int rc;
+    const char *program_profile = "TEST_PROFILE";
+    const char *env_profile = getenv("LIXA_PROFILE");
+
+    printf("LIXA_PROFILE = %s\n", env_profile ? env_profile : "(Not specified)");
+
+    printf("tx_set_profile(%s): %d\n", program_profile, rc = tx_set_profile( program_profile ));
+    if (TX_OK != rc) exit(1);
+
+    /* If LIXA_PROFILE is set, its value will override the tx_set_profile() */
+    
+    printf("tx_open(): %d\n", rc = tx_open());
+    if (TX_OK != rc) exit(1);
+    
+    printf("tx_begin(): %d\n", rc = tx_begin());
+    if (TX_OK != rc) exit(1);
+    printf("tx_end(TMSUSPEND): %d\n", rc = tx_end(TX_TMSUSPEND));
+    if (TX_OK != rc) exit(1);
+    TXINFO txinfo;
+    printf("tx_info(): %d\n", rc = tx_info(&txinfo));
+    if(0 != rc && 1 != rc) exit(1);
+    printf("tx_resume(): %d\n", rc = tx_resume(&txinfo.xid));
+    if (TX_OK != rc) exit(1);
+    printf("tx_commit(): %d\n", rc = tx_commit());
+    if (TX_OK != rc) exit(1);
+
+    printf("tx_begin(): %d\n", rc = tx_begin());
+    if (TX_OK != rc) exit(1);
+    printf("tx_end(TMSUSPEND): %d\n", rc = tx_end(TX_TMSUSPEND));
+    if (TX_OK != rc) exit(1);
+    printf("tx_info(): %d\n", rc = tx_info(&txinfo));
+    if(0 != rc && 1 != rc) exit(1);
+    printf("tx_resume(): %d\n", rc = tx_resume(&txinfo.xid));
+    if (TX_OK != rc) exit(1);
+    printf("tx_rollback(): %d\n", rc = tx_rollback());
+    if (TX_OK != rc) exit(1);
+    
+    printf("tx_close(): %d\n", rc = tx_close());
+    if (TX_OK != rc) exit(1);
+    return 0;
+}

--- a/doc/manuals/LIXA_Development_TC.xml
+++ b/doc/manuals/LIXA_Development_TC.xml
@@ -316,4 +316,63 @@ tx_close(): 0
       </section>
     </section>
   </section>
+  <section>
+    <title>Non-standard TX (Transaction Demarcation) Specification Extensions</title>
+    <para>
+      The LIXA project provides an extension to the <citation>TXspec</citation>,
+      to set the Resource Manager profile programatically
+      <footnote>
+	<para>
+	  This extension to the TX specification was designed and has been
+	  provided to the LIXA project by 
+	  <ulink url="http://www.lzlabs.com/">LzLabs GmbH</ulink>
+	</para>
+      </footnote>, which can be used in addition to the 
+      standard API when developing Application Programs.
+    </para>
+    <para>
+      The following C example briefly explains it:
+      <programlisting>
+#include &lt;tx.h&gt;
+        
+/* your includes */
+
+static bool mysql_exists() {
+    return true;
+}
+        
+int main(int argc, char *argv[])
+{
+    int rc;
+    const char *basic_profile = "PROF_SP";
+
+    char program_profile[50];
+    if ( mysql_exists() ) {
+        snprintf( program_profile, sizeof(program_profile), "%s_WITH_MYSQL", basic_profile );
+    } else {
+        snprintf( program_profile, sizeof(program_profile), "%s", basic_profile );
+    }
+
+    if (TX_OK != (rc = tx_set_profile( program_profile )))
+        /* handle error */
+        
+    if (TX_OK != (rc = tx_open()))
+        /* handle error - specified profile name is checked */
+        /* during tx_open */
+        
+    if (TX_OK != (rc = tx_begin()))
+        /* handle error */
+        
+    /* do local work against Resource Managers here */
+        
+    /* commit or roll back transaction */
+    if (TX_OK != (rc = tx_commit()))
+        /* handle errror */
+        
+    /* shut down */
+    tx_close();
+}
+      </programlisting>
+    </para>
+  </section>
 </chapter>

--- a/src/client/client_config.c
+++ b/src/client/client_config.c
@@ -163,22 +163,24 @@ int client_config(client_config_coll_t *ccc, int global_config, const char *prof
             ccc->profiles = g_array_new(FALSE, FALSE, sizeof(
                                             struct profile_config_s));
         
-        if (profile) {
-            LIXA_TRACE(("client_config: using transactional profile '%s' for "
-                        "subsequent operations\n", profile));
-            if (NULL == (ccc->profile = g_strdup(profile)))
-                THROW(G_STRDUP_ERROR);
-        } else if (NULL == (tmp_str = getenv(LIXA_PROFILE_ENV_VAR))) {
-            /* use empty string instead of NULL to avoid allocation issues */
-            ccc->profile = tmp_str;
-            LIXA_TRACE(("client_config: '%s' environment variable not found, "
-                        "using default profile for this client\n",
-                        LIXA_PROFILE_ENV_VAR));
-        } else {
-            LIXA_TRACE(("client_config: using transactional profile '%s' for "
+        if (NULL != (tmp_str = getenv(LIXA_PROFILE_ENV_VAR))) {
+            LIXA_TRACE(("client_config: using environment transactional profile '%s' for "
                         "subsequent operations\n", tmp_str));
             if (NULL == (ccc->profile = g_strdup(tmp_str)))
                 THROW(G_STRDUP_ERROR2);
+        } else {
+            if (profile) {
+                LIXA_TRACE(("client_config: using application transactional profile '%s' for "
+                            "subsequent operations\n", profile));
+                if (NULL == (ccc->profile = g_strdup(profile)))
+                    THROW(G_STRDUP_ERROR);
+            } else {
+                /* use empty string instead of NULL to avoid allocation issues */
+                ccc->profile = tmp_str;
+                LIXA_TRACE(("client_config: '%s' environment variable not found, "
+                            "using default profile for this client\n",
+                            LIXA_PROFILE_ENV_VAR));
+            }
         }
 
         /* checking if available the custom config file */

--- a/src/client/client_config.h
+++ b/src/client/client_config.h
@@ -282,9 +282,11 @@ extern "C" {
      *                            global static config shared by all the
      *                            threads, XTA API uses a local dynamic
      *                            object for every thread.
+     * @param[in] profile : If non-NULL, this name is used in place of the
+     *                            LIXA_PROFILE environment variable.
      * @return a reason code
      */
-    int client_config(client_config_coll_t *ccc, int global_config);
+    int client_config(client_config_coll_t *ccc, int global_config, const char *profile);
 
 
 

--- a/src/client/lixa_tx.c
+++ b/src/client/lixa_tx.c
@@ -72,7 +72,8 @@ int lixa_tx_set_profile(int *txrc, const char *profile)
     g_mutex_lock( &profile_mutex );
     TRY {
         if (tx_open_profile) {
-            free(g_steal_pointer(&tx_open_profile));
+            free(tx_open_profile);
+            tx_open_profile = NULL;
         }
         if (profile) {
 	    tx_open_profile = g_strdup(profile);
@@ -86,14 +87,14 @@ int lixa_tx_set_profile(int *txrc, const char *profile)
         }
     } CATCH {
         switch (excp) {
-        default:
-        case G_STRDUP_ERROR:
-            ret_cod = LIXA_RC_G_STRDUP_ERROR;
-            *txrc = TX_FAIL;
-            break;
         case NONE:
             ret_cod = LIXA_RC_OK;
             *txrc = TX_OK;
+            break;
+        case G_STRDUP_ERROR:
+        default:
+            ret_cod = LIXA_RC_G_STRDUP_ERROR;
+            *txrc = TX_FAIL;
             break;
         }
     }

--- a/src/client/lixa_tx.c
+++ b/src/client/lixa_tx.c
@@ -92,11 +92,14 @@ int lixa_tx_set_profile(int *txrc, const char *profile)
             *txrc = TX_OK;
             break;
         case G_STRDUP_ERROR:
-        default:
             ret_cod = LIXA_RC_G_STRDUP_ERROR;
             *txrc = TX_FAIL;
             break;
-        }
+        default:
+            ret_cod = LIXA_RC_INTERNAL_ERROR;
+            *txrc = TX_FAIL;
+            break;
+         }
     }
     g_mutex_unlock( &profile_mutex );
     LIXA_TRACE(("lixa_tx_set_profile/TX_*=%d/excp=%d/"

--- a/src/client/lixa_tx.c
+++ b/src/client/lixa_tx.c
@@ -56,8 +56,18 @@
 static const char *tx_open_profile = NULL;
 
 int lixa_tx_set_profile(const char *profile) {
-    tx_open_profile = profile;
-    return 0;
+    if (tx_open_profile) {
+        free((char*)tx_open_profile);
+    }
+    if (profile) {
+	tx_open_profile = strdup(profile);
+        if (tx_open_profile == NULL) {
+	    return TX_FAIL;
+        }
+    } else {
+        tx_open_profile = NULL;
+    }
+    return TX_OK;
 }
 
 
@@ -339,6 +349,9 @@ int lixa_tx_close(int *txrc)
             default:
                 THROW(INVALID_STATUS);
         }
+
+        /* Clear profile override */
+        lixa_tx_set_profile(NULL);
 
         /* update the TX state, now TX_STATE_S0; the result of XA calls
            must not be waited; see bug 3006369 */

--- a/src/client/lixa_tx.c
+++ b/src/client/lixa_tx.c
@@ -53,6 +53,13 @@
 #endif /* LIXA_TRACE_MODULE */
 #define LIXA_TRACE_MODULE   LIXA_TRACE_MOD_CLIENT_TX
 
+static const char *tx_open_profile = NULL;
+
+int lixa_tx_set_profile(const char *profile) {
+    tx_open_profile = profile;
+    return 0;
+}
+
 
 
 int lixa_tx_begin(int *txrc, XID *xid, int flags)
@@ -1004,7 +1011,7 @@ int lixa_tx_open(int *txrc, int mmode)
         /* check TX state (see Table 7-1) */
         txstate = client_status_get_txstate(cs);
         if (txstate == TX_STATE_S0) {
-            if (LIXA_RC_OK != (ret_cod = client_config(&global_ccc, TRUE)))
+            if (LIXA_RC_OK != (ret_cod = client_config(&global_ccc, TRUE, tx_open_profile)))
                 THROW(CLIENT_CONFIG_ERROR);
             if (LIXA_RC_OK != (ret_cod = client_connect(cs, &global_ccc)))
                 THROW(CLIENT_CONNECT_ERROR);

--- a/src/client/lixa_tx.h
+++ b/src/client/lixa_tx.h
@@ -216,11 +216,14 @@ extern "C" {
 
 
     /**
-     * Set the profile name, overrides the LIXA_PROFILE environment variable
+     * Set the profile name to use
+     * <b>Note:</b> This is a non standard function.
+     * The LIXA_PROFILE environment variable, if present, will override this value
+     * @param[out] txrc tx_* return code
      * @param[in] profile, NULL will remove the override, otherwise the profile must exist in the conf file
-     * @return 0 = OK, non-zero = error
+     * @return a standardised return code
      */
-    extern int lixa_tx_set_profile(const char *profile);
+    extern int lixa_tx_set_profile(int *txrc, const char *profile);
 
 
     

--- a/src/client/lixa_tx.h
+++ b/src/client/lixa_tx.h
@@ -214,6 +214,15 @@ extern "C" {
     void lixa_tx_cleanup(void);
 
 
+
+    /**
+     * Set the profile name, overrides the LIXA_PROFILE environment variable
+     * @param[in] profile, NULL will remove the override, otherwise the profile must exist in the conf file
+     * @return 0 = OK, non-zero = error
+     */
+    extern int lixa_tx_set_profile(const char *profile);
+
+
     
 #ifdef __cplusplus
 }

--- a/src/client/lixavsr.c
+++ b/src/client/lixavsr.c
@@ -1630,7 +1630,7 @@ int main(int argc, char *argv[])
     }
 
     /* configure a client standard environment */
-    if (LIXA_RC_OK != (ret_cod = client_config(&global_ccc, TRUE))) {
+    if (LIXA_RC_OK != (ret_cod = client_config(&global_ccc, TRUE, NULL))) {
         LIXA_TRACE(("%s/client_config: ret_cod=%d ('%s')\n", argv[0],
                     ret_cod, lixa_strerror(ret_cod)));
         exit(1);

--- a/src/client/tx.c
+++ b/src/client/tx.c
@@ -202,3 +202,10 @@ int tx_xid_deserialize(TXINFO *info, char *sxid) {
     txrc = TX_OK;
     return txrc;
 }
+
+int tx_set_profile(const char *profile) {
+    int txrc = TX_FAIL;
+    lixa_tx_set_profile( &txrc, profile );
+    return txrc;
+}
+

--- a/src/client/tx.h
+++ b/src/client/tx.h
@@ -233,6 +233,16 @@ extern "C" {
  */
     extern int tx_xid_deserialize(TXINFO *info, char *sxid);
 
+/**
+ * Set a Resource Manager profile
+ * This should be called prior to calling @ref tx_open
+ * This profile name can be overridden by the LIXA_PROFILE environment variable
+ * This is NOT a standard Transaction Demarcation function
+ * @param profile IN the profile name, or NULL for none
+ * @return a standardized TX return code (TX_*)
+ */
+    extern int tx_set_profile(const char *profile);
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/src/xta/xta_transaction_manager.c
+++ b/src/xta/xta_transaction_manager.c
@@ -58,7 +58,7 @@ xta_transaction_manager_t *xta_transaction_manager_new(void)
         /* initialize the mutex */
         g_mutex_init(&this->mutex);
         /* configure the global config for LIXA client (if necessary) */
-        if (LIXA_RC_OK != (ret_cod = client_config(&global_ccc, TRUE)))
+        if (LIXA_RC_OK != (ret_cod = client_config(&global_ccc, TRUE, NULL)))
             THROW(CLIENT_CONFIG_ERROR);
         THROW(NONE);
     } CATCH {

--- a/tests/src/Makefile.am
+++ b/tests/src/Makefile.am
@@ -52,7 +52,7 @@ check_PROGRAMS = case0000 case0001 case0002 case0003 case0004 case0005 \
 	case0020 case0021 case0022 case0023 case0024 case0025 case0026 \
 	case0027 case0028 case0029 case0030 case0031 case0032 case0033 \
 	case0034 case0035 case0036 case0043 case0046 case0048 case0049 \
-	case0050 case0051 case0052 case0053 \
+	case0050 case0051 case0052 case0053 case0054 \
 	$(MAYBE_POSTGRESQL) $(MAYBE_ORACLE) \
 	$(MAYBE_IBMDB2) $(MAYBE_MYSQL) $(MAYBE_MYSQL_POSTGRESQL) \
 	$(MAYBE_WEBSPHEREMQ) $(MAYBE_XTA)
@@ -162,6 +162,7 @@ case0050_SOURCES = case0050.c
 case0051_SOURCES = case0051.c
 case0052_SOURCES = case0052.c
 case0053_SOURCES = case0053.c
+case0054_SOURCES = case0054.c
 case0100_CPPFLAGS = -I../../src/client -I../../src/common -I../../src \
 	@ORACLE_OCI_CFLAGS@ @MYSQL_CPPFLAGS@ @POSTGRESQL_CPPFLAGS@
 case0100_LDADD = ../../src/common/liblixab.la ../../src/client/liblixac.la \

--- a/tests/src/case0038.c
+++ b/tests/src/case0038.c
@@ -32,8 +32,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef HAVE_ORACLE
 /* Oracle C Interface API header */
 #include <oci.h>
+#endif
 
 /* TX (Transaction Demarcation) header */
 #include <tx.h>

--- a/tests/src/case0038.c
+++ b/tests/src/case0038.c
@@ -32,10 +32,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifdef HAVE_ORACLE
 /* Oracle C Interface API header */
 #include <oci.h>
-#endif
 
 /* TX (Transaction Demarcation) header */
 #include <tx.h>

--- a/tests/src/case0054.c
+++ b/tests/src/case0054.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2009-2020, Christian Ferrari <tiian@users.sourceforge.net>
+ * All rights reserved.
+ *
+ * This file is part of LIXA.
+ *
+ * LIXA is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation.
+ *
+ * LIXA is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LIXA.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <config.h>
+
+
+
+#ifdef HAVE_STDIO_H
+# include <stdio.h>
+#endif
+#ifdef HAVE_UNISTD_H
+# include <unistd.h>
+#endif
+#ifdef HAVE_ASSERT_H
+# include <assert.h>
+#endif
+
+
+
+#include <tx.h>
+#include <liblixamonkey.h>
+
+
+
+/* this is a special case test: it is a basic test for statically registered
+   resource managers with a code-specified profile supplied as an argument */
+
+
+
+int main(int argc, char *argv[])
+{
+    char *pgm = argv[0];
+    char *profile = NULL;
+    int rc;
+    TXINFO info;
+
+    if (argc > 0) {
+        profile = argv[1];
+    }
+    
+    printf("%s| starting...\n", pgm);
+    printf("%s| lixa_tx_set_profile(%s): %d\n", pgm, profile ? profile : "NULL", rc = lixa_tx_set_profile(profile));
+    assert(TX_OK == rc);
+    printf("%s| tx_open(): %d\n", pgm, rc = tx_open());
+    if (TX_ERROR == rc) {
+        /* memory leak prevention */
+        printf("%s| tx_close(): %d\n", pgm, rc = tx_close());
+        lixa_monkeyrm_call_cleanup();
+    }
+    assert(TX_OK == rc);
+    printf("%s| tx_begin(): %d\n", pgm, rc = tx_begin());
+    assert(TX_OK == rc);
+    printf("%s| tx_info(): %d\n", pgm, rc = tx_info(&info));
+    assert(1 == rc);
+    printf("%s| tx_commit(): %d\n", pgm, rc = tx_commit());
+    assert(TX_OK == rc);
+    printf("%s| tx_close(): %d\n", pgm, rc = tx_close());
+    assert(TX_OK == rc);
+
+    /* memory leak prevention */
+    lixa_monkeyrm_call_cleanup();
+
+    printf("%s| ...finished\n", pgm);
+    return 0;
+}

--- a/tests/src/case0054.c
+++ b/tests/src/case0054.c
@@ -33,6 +33,7 @@
 
 
 #include <tx.h>
+#include <lixa_tx.h>
 #include <liblixamonkey.h>
 
 

--- a/tests/src/case0054.c
+++ b/tests/src/case0054.c
@@ -33,7 +33,6 @@
 
 
 #include <tx.h>
-#include <lixa_tx.h>
 #include <liblixamonkey.h>
 
 
@@ -47,6 +46,7 @@ int main(int argc, char *argv[])
 {
     char *pgm = argv[0];
     char *profile = NULL;
+    char *missing_profile = "MISSING_PROFILE";
     int rc;
     TXINFO info;
 
@@ -55,13 +55,22 @@ int main(int argc, char *argv[])
     }
     
     printf("%s| starting...\n", pgm);
-    printf("%s| lixa_tx_set_profile(%s): %d\n", pgm, profile ? profile : "NULL", rc = lixa_tx_set_profile(profile));
+    printf("%s| tx_set_profile(%s): %d\n", pgm, missing_profile, rc = tx_set_profile(missing_profile));
+    assert(TX_OK == rc);
+    printf("%s| tx_set_profile(%s): %d\n", pgm, profile ? profile : "NULL", rc = tx_set_profile(profile));
     assert(TX_OK == rc);
     printf("%s| tx_open(): %d\n", pgm, rc = tx_open());
     if (TX_ERROR == rc) {
         /* memory leak prevention */
         printf("%s| tx_close(): %d\n", pgm, rc = tx_close());
         lixa_monkeyrm_call_cleanup();
+    }
+    if (TX_FAIL == rc) {
+        /* memory leak prevention */
+        printf("%s| tx_close(): %d\n", pgm, rc = tx_close());
+        lixa_monkeyrm_call_cleanup();
+        printf("%s| ...finished\n", pgm);
+        return 1;
     }
     assert(TX_OK == rc);
     printf("%s| tx_begin(): %d\n", pgm, rc = tx_begin());

--- a/tests/tx_3_2.at
+++ b/tests/tx_3_2.at
@@ -21,6 +21,27 @@ xa_close/0
 AT_CHECK([export LIXA_PROFILE=CASE_PROF_0000 ; lixa_test_exec.sh reset recycle case0000 2>&1 | tee $TESTS_TMP_FILE1 ; grep 'lixa_monkeyrm_close' $TESTS_TMP_FILE1 | grep 'ret_cod' | wc -l | grep 3], [0], [ignore], [ignore])
 AT_CLEANUP
 
+AT_SETUP([TX/3.2/0.1])
+# As for TX/3.2/0.0 but profile CASE_PROF_0000 is specified by the test program
+# and overrides the CASE_PROF_0001 specified by LIXA_PROFILE
+AT_DATA([monkey1s.conf],
+[[# first monkey R.M. config
+xa_open/0
+xa_close/0
+]])
+AT_DATA([monkey2s.conf],
+[[# second monkey R.M. config
+xa_open/-3
+xa_close/0
+]])
+AT_DATA([monkey3s.conf],
+[[# third monkey R.M. config
+xa_open/0
+xa_close/0
+]])
+AT_CHECK([export LIXA_PROFILE=CASE_PROF_0001 ; lixa_test_exec.sh reset recycle case0054 CASE_PROF_0000 2>&1 | tee $TESTS_TMP_FILE1 ; grep 'lixa_monkeyrm_close' $TESTS_TMP_FILE1 | grep 'ret_cod' | wc -l | grep 3], [0], [ignore], [ignore])
+AT_CLEANUP
+
 AT_SETUP([TX/3.2/1.0])
 # "The AP calls tx_close( ) to close all RMs linked with the AP. 
 # For tx_close( ) to return success, the AP cannot be part of an active global

--- a/tests/tx_3_2.at
+++ b/tests/tx_3_2.at
@@ -22,8 +22,33 @@ AT_CHECK([export LIXA_PROFILE=CASE_PROF_0000 ; lixa_test_exec.sh reset recycle c
 AT_CLEANUP
 
 AT_SETUP([TX/3.2/0.1])
-# As for TX/3.2/0.0 but profile CASE_PROF_0000 is specified by the test program
-# and overrides the CASE_PROF_0001 specified by LIXA_PROFILE
+# As for TX/3.2/0.0 but profile CASE_PROF_0002 is specified by the test program
+AT_DATA([monkey1s.conf],
+[[# first monkey R.M. config
+xa_open/0
+xa_close/0
+]])
+AT_DATA([monkey2s.conf],
+[[# second monkey R.M. config
+xa_open/-3
+xa_close/0
+]])
+AT_DATA([monkey1d.conf],
+[[# third monkey R.M. config
+xa_open/0
+xa_close/0
+]])
+AT_DATA([monkey2d.conf],
+[[# fourth monkey R.M. config
+xa_open/0
+xa_close/0
+]])
+AT_CHECK([lixa_test_exec.sh reset recycle case0054 CASE_PROF_0002 2>&1 | tee $TESTS_TMP_FILE1 ; grep 'lixa_monkeyrm_close' $TESTS_TMP_FILE1 | grep 'ret_cod' | wc -l | grep 4], [0], [ignore], [ignore])
+AT_CLEANUP
+
+AT_SETUP([TX/3.2/0.2])
+# As for TX/3.2/0.0 but profile CASE_PROF_0000 is specified by LIXA_PROFILE
+# and overrides the CASE_PROF_0001 specified by the program
 AT_DATA([monkey1s.conf],
 [[# first monkey R.M. config
 xa_open/0
@@ -39,7 +64,28 @@ AT_DATA([monkey3s.conf],
 xa_open/0
 xa_close/0
 ]])
-AT_CHECK([export LIXA_PROFILE=CASE_PROF_0001 ; lixa_test_exec.sh reset recycle case0054 CASE_PROF_0000 2>&1 | tee $TESTS_TMP_FILE1 ; grep 'lixa_monkeyrm_close' $TESTS_TMP_FILE1 | grep 'ret_cod' | wc -l | grep 3], [0], [ignore], [ignore])
+AT_CHECK([export LIXA_PROFILE=CASE_PROF_0000; lixa_test_exec.sh reset recycle case0054 CASE_PROF_0001 2>&1 | tee $TESTS_TMP_FILE1 ; grep 'lixa_monkeyrm_close' $TESTS_TMP_FILE1 | grep 'ret_cod' | wc -l | grep 3], [0], [ignore], [ignore])
+AT_CLEANUP
+
+AT_SETUP([TX/3.2/0.2])
+# As for TX/3.2/0.0 but no profile is specified by LIXA_PROFILE
+# or by the program, so should default to CASE_PROF_0000
+AT_DATA([monkey1s.conf],
+[[# first monkey R.M. config
+xa_open/0
+xa_close/0
+]])
+AT_DATA([monkey2s.conf],
+[[# second monkey R.M. config
+xa_open/-3
+xa_close/0
+]])
+AT_DATA([monkey3s.conf],
+[[# third monkey R.M. config
+xa_open/0
+xa_close/0
+]])
+AT_CHECK([lixa_test_exec.sh reset recycle case0054 2>&1 | tee $TESTS_TMP_FILE1 ; grep 'lixa_monkeyrm_close' $TESTS_TMP_FILE1 | grep 'ret_cod' | wc -l | grep 3], [0], [ignore], [ignore])
 AT_CLEANUP
 
 AT_SETUP([TX/3.2/1.0])

--- a/tests/tx_3_2.at
+++ b/tests/tx_3_2.at
@@ -67,6 +67,32 @@ xa_close/0
 AT_CHECK([export LIXA_PROFILE=CASE_PROF_0000; lixa_test_exec.sh reset recycle case0054 CASE_PROF_0001 2>&1 | tee $TESTS_TMP_FILE1 ; grep 'lixa_monkeyrm_close' $TESTS_TMP_FILE1 | grep 'ret_cod' | wc -l | grep 3], [0], [ignore], [ignore])
 AT_CLEANUP
 
+AT_SETUP([TX/3.2/0.3])
+# As for TX/3.2/0.0 but profile MISSING_PROF is specified by the program
+AT_CHECK([lixa_test_exec.sh reset recycle case0054 MISSING_PROF 2>&1], [1], [ignore], [ignore])
+AT_CLEANUP
+
+AT_SETUP([TX/3.2/0.4])
+# As for TX/3.2/0.0 but profile CASE_PROF_0000 is specified by LIXA_PROFILE
+# and overrides the MISSING_PROF specified by the program
+AT_DATA([monkey1s.conf],
+[[# first monkey R.M. config
+xa_open/0
+xa_close/0
+]])
+AT_DATA([monkey2s.conf],
+[[# second monkey R.M. config
+xa_open/-3
+xa_close/0
+]])
+AT_DATA([monkey3s.conf],
+[[# third monkey R.M. config
+xa_open/0
+xa_close/0
+]])
+AT_CHECK([export LIXA_PROFILE=CASE_PROF_0000; lixa_test_exec.sh reset recycle case0054 MISSING_PROF 2>&1 | tee $TESTS_TMP_FILE1 ; grep 'lixa_monkeyrm_close' $TESTS_TMP_FILE1 | grep 'ret_cod' | wc -l | grep 3], [0], [ignore], [ignore])
+AT_CLEANUP
+
 AT_SETUP([TX/3.2/0.2])
 # As for TX/3.2/0.0 but no profile is specified by LIXA_PROFILE
 # or by the program, so should default to CASE_PROF_0000

--- a/tests/tx_3_2.at
+++ b/tests/tx_3_2.at
@@ -93,7 +93,7 @@ xa_close/0
 AT_CHECK([export LIXA_PROFILE=CASE_PROF_0000; lixa_test_exec.sh reset recycle case0054 MISSING_PROF 2>&1 | tee $TESTS_TMP_FILE1 ; grep 'lixa_monkeyrm_close' $TESTS_TMP_FILE1 | grep 'ret_cod' | wc -l | grep 3], [0], [ignore], [ignore])
 AT_CLEANUP
 
-AT_SETUP([TX/3.2/0.2])
+AT_SETUP([TX/3.2/0.5])
 # As for TX/3.2/0.0 but no profile is specified by LIXA_PROFILE
 # or by the program, so should default to CASE_PROF_0000
 AT_DATA([monkey1s.conf],

--- a/tests/tx_cobol.at
+++ b/tests/tx_cobol.at
@@ -63,3 +63,8 @@ AT_CHECK([if test "$HAVE_COBOLAPI" = "no"; then exit 77; fi])
 AT_CHECK([lixa_test_exec.sh noreset stop CASE1000], [ignore], [ignore], [ignore])
 AT_CLEANUP
 
+AT_SETUP([Stopping lixad process])
+AT_CHECK([if test "$HAVE_COBOLAPI" = "yes"; then exit 77; fi])
+AT_CHECK([lixa_test_exec.sh noreset stop true], [ignore], [ignore], [ignore])
+AT_CLEANUP
+

--- a/tests/xta_8_0.at
+++ b/tests/xta_8_0.at
@@ -198,6 +198,7 @@ xa_close/0
 AT_CHECK([export LIXA_PROFILE=CASE_PROF_0038; lixa_test_exec.sh noreset none case0100 0 1 0 2>&1], [0], [ignore], [ignore])
 AT_CLEANUP
 AT_SETUP([XTA/8.0/5.1 automatic recovery])
+AT_CHECK([if test "$LIXA_XTA" = "no"; then exit 77; fi])
 # recover previous prepared transaction and delete rows from tables
 # TRADITIONAL state engine misses the
 # rollback state and requires a further rollback; JOURNAL state engine saves


### PR DESCRIPTION
Here is our first addition to the lixa_tx API, to allow the application to specify the profile prior to tx_open with a lixa_tx_set_profile(const char *profile). This setting will override the LIXA_PROFILE environment value. The override is cleared on tx_close.
The test changes (case0038.c, tx_cobol.at, xta_8_0.at) were required to allow "make check" to work in our environment.